### PR TITLE
Add TCP listening option for desktop connections

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -37,6 +37,8 @@ public class Options {
     private float maxFps;
     private float angle;
     private boolean tunnelForward;
+    private String listenAddress;
+    private int listenPort = -1;
     private Rect crop;
     private boolean control = true;
     private int displayId;
@@ -138,6 +140,18 @@ public class Options {
 
     public boolean isTunnelForward() {
         return tunnelForward;
+    }
+
+    public String getListenAddress() {
+        return listenAddress;
+    }
+
+    public int getListenPort() {
+        return listenPort;
+    }
+
+    public boolean useTcpConnection() {
+        return listenAddress != null || listenPort != -1;
     }
 
     public Rect getCrop() {
@@ -375,6 +389,17 @@ public class Options {
                     break;
                 case "tunnel_forward":
                     options.tunnelForward = Boolean.parseBoolean(value);
+                    break;
+                case "listen_address":
+                    if (!value.isEmpty()) {
+                        options.listenAddress = value;
+                    }
+                    break;
+                case "listen_port":
+                    options.listenPort = Integer.parseInt(value);
+                    if (options.listenPort < 0) {
+                        throw new IllegalArgumentException("listen_port may not be negative: " + options.listenPort);
+                    }
                     break;
                 case "crop":
                     if (!value.isEmpty()) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -91,7 +91,8 @@ public final class Server {
         }
 
         int scid = options.getScid();
-        boolean tunnelForward = options.isTunnelForward();
+        boolean useTcpConnection = options.useTcpConnection();
+        boolean tunnelForward = useTcpConnection ? false : options.isTunnelForward();
         boolean control = options.getControl();
         boolean video = options.getVideo();
         boolean audio = options.getAudio();
@@ -101,7 +102,8 @@ public final class Server {
 
         List<AsyncProcessor> asyncProcessors = new ArrayList<>();
 
-        DesktopConnection connection = DesktopConnection.open(scid, tunnelForward, video, audio, control, sendDummyByte);
+        DesktopConnection connection = DesktopConnection.open(scid, tunnelForward, video, audio, control, sendDummyByte,
+                options.getListenAddress(), options.getListenPort());
         try {
             if (options.getSendDeviceMeta()) {
                 connection.sendDeviceMeta(Device.getDeviceName());

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlChannel.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlChannel.java
@@ -3,6 +3,8 @@ package com.genymobile.scrcpy.control;
 import android.net.LocalSocket;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public final class ControlChannel {
 
@@ -10,8 +12,12 @@ public final class ControlChannel {
     private final DeviceMessageWriter writer;
 
     public ControlChannel(LocalSocket controlSocket) throws IOException {
-        reader = new ControlMessageReader(controlSocket.getInputStream());
-        writer = new DeviceMessageWriter(controlSocket.getOutputStream());
+        this(controlSocket.getInputStream(), controlSocket.getOutputStream());
+    }
+
+    public ControlChannel(InputStream inputStream, OutputStream outputStream) throws IOException {
+        reader = new ControlMessageReader(inputStream);
+        writer = new DeviceMessageWriter(outputStream);
     }
 
     public ControlMessage recv() throws IOException {

--- a/server/src/main/java/com/genymobile/scrcpy/device/DesktopConnection.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/DesktopConnection.java
@@ -7,10 +7,17 @@ import com.genymobile.scrcpy.util.StringUtils;
 import android.net.LocalServerSocket;
 import android.net.LocalSocket;
 import android.net.LocalSocketAddress;
+import android.os.ParcelFileDescriptor;
 
 import java.io.Closeable;
 import java.io.FileDescriptor;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
 public final class DesktopConnection implements Closeable {
@@ -19,23 +26,124 @@ public final class DesktopConnection implements Closeable {
 
     private static final String SOCKET_NAME_PREFIX = "scrcpy";
 
-    private final LocalSocket videoSocket;
+    private interface Endpoint extends Closeable {
+        FileDescriptor getFileDescriptor();
+
+        InputStream getInputStream() throws IOException;
+
+        OutputStream getOutputStream() throws IOException;
+
+        void shutdown() throws IOException;
+    }
+
+    private static final class LocalSocketEndpoint implements Endpoint {
+
+        private final LocalSocket socket;
+
+        LocalSocketEndpoint(LocalSocket socket) {
+            this.socket = socket;
+        }
+
+        @Override
+        public FileDescriptor getFileDescriptor() {
+            return socket.getFileDescriptor();
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return socket.getInputStream();
+        }
+
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return socket.getOutputStream();
+        }
+
+        @Override
+        public void shutdown() throws IOException {
+            socket.shutdownInput();
+            socket.shutdownOutput();
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+        }
+    }
+
+    private static final class TcpSocketEndpoint implements Endpoint {
+
+        private final Socket socket;
+        private final ParcelFileDescriptor parcelFileDescriptor;
+        private final FileDescriptor fileDescriptor;
+
+        TcpSocketEndpoint(Socket socket) throws IOException {
+            this.socket = socket;
+            parcelFileDescriptor = ParcelFileDescriptor.fromSocket(socket);
+            fileDescriptor = parcelFileDescriptor.getFileDescriptor();
+        }
+
+        @Override
+        public FileDescriptor getFileDescriptor() {
+            return fileDescriptor;
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return socket.getInputStream();
+        }
+
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return socket.getOutputStream();
+        }
+
+        @Override
+        public void shutdown() throws IOException {
+            socket.shutdownInput();
+            socket.shutdownOutput();
+        }
+
+        @Override
+        public void close() throws IOException {
+            IOException error = null;
+            try {
+                parcelFileDescriptor.close();
+            } catch (IOException e) {
+                error = e;
+            }
+            try {
+                socket.close();
+            } catch (IOException e) {
+                if (error == null) {
+                    error = e;
+                }
+            }
+            if (error != null) {
+                throw error;
+            }
+        }
+    }
+
+    private final Endpoint videoEndpoint;
     private final FileDescriptor videoFd;
 
-    private final LocalSocket audioSocket;
+    private final Endpoint audioEndpoint;
     private final FileDescriptor audioFd;
 
-    private final LocalSocket controlSocket;
+    private final Endpoint controlEndpoint;
     private final ControlChannel controlChannel;
 
-    private DesktopConnection(LocalSocket videoSocket, LocalSocket audioSocket, LocalSocket controlSocket) throws IOException {
-        this.videoSocket = videoSocket;
-        this.audioSocket = audioSocket;
-        this.controlSocket = controlSocket;
+    private DesktopConnection(Endpoint videoEndpoint, Endpoint audioEndpoint, Endpoint controlEndpoint) throws IOException {
+        this.videoEndpoint = videoEndpoint;
+        this.audioEndpoint = audioEndpoint;
+        this.controlEndpoint = controlEndpoint;
 
-        videoFd = videoSocket != null ? videoSocket.getFileDescriptor() : null;
-        audioFd = audioSocket != null ? audioSocket.getFileDescriptor() : null;
-        controlChannel = controlSocket != null ? new ControlChannel(controlSocket) : null;
+        videoFd = videoEndpoint != null ? videoEndpoint.getFileDescriptor() : null;
+        audioFd = audioEndpoint != null ? audioEndpoint.getFileDescriptor() : null;
+        controlChannel = controlEndpoint != null
+                ? new ControlChannel(controlEndpoint.getInputStream(), controlEndpoint.getOutputStream())
+                : null;
     }
 
     private static LocalSocket connect(String abstractName) throws IOException {
@@ -53,102 +161,175 @@ public final class DesktopConnection implements Closeable {
         return SOCKET_NAME_PREFIX + String.format("_%08x", scid);
     }
 
-    public static DesktopConnection open(int scid, boolean tunnelForward, boolean video, boolean audio, boolean control, boolean sendDummyByte)
-            throws IOException {
+    private static void closeSilently(Endpoint endpoint) {
+        if (endpoint != null) {
+            try {
+                endpoint.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    public static DesktopConnection open(int scid, boolean tunnelForward, boolean video, boolean audio, boolean control,
+            boolean sendDummyByte, String listenAddress, int listenPort) throws IOException {
+        if (listenAddress != null || listenPort != -1) {
+            return openTcp(listenAddress, listenPort, video, audio, control, sendDummyByte);
+        }
+
+        return openLocal(scid, tunnelForward, video, audio, control, sendDummyByte);
+    }
+
+    private static DesktopConnection openLocal(int scid, boolean tunnelForward, boolean video, boolean audio, boolean control,
+            boolean sendDummyByte) throws IOException {
         String socketName = getSocketName(scid);
 
-        LocalSocket videoSocket = null;
-        LocalSocket audioSocket = null;
-        LocalSocket controlSocket = null;
+        Endpoint videoEndpoint = null;
+        Endpoint audioEndpoint = null;
+        Endpoint controlEndpoint = null;
         try {
             if (tunnelForward) {
                 try (LocalServerSocket localServerSocket = new LocalServerSocket(socketName)) {
                     if (video) {
-                        videoSocket = localServerSocket.accept();
+                        videoEndpoint = new LocalSocketEndpoint(localServerSocket.accept());
                         if (sendDummyByte) {
-                            // send one byte so the client may read() to detect a connection error
-                            videoSocket.getOutputStream().write(0);
+                            videoEndpoint.getOutputStream().write(0);
                             sendDummyByte = false;
                         }
                     }
                     if (audio) {
-                        audioSocket = localServerSocket.accept();
+                        audioEndpoint = new LocalSocketEndpoint(localServerSocket.accept());
                         if (sendDummyByte) {
-                            // send one byte so the client may read() to detect a connection error
-                            audioSocket.getOutputStream().write(0);
+                            audioEndpoint.getOutputStream().write(0);
                             sendDummyByte = false;
                         }
                     }
                     if (control) {
-                        controlSocket = localServerSocket.accept();
+                        controlEndpoint = new LocalSocketEndpoint(localServerSocket.accept());
                         if (sendDummyByte) {
-                            // send one byte so the client may read() to detect a connection error
-                            controlSocket.getOutputStream().write(0);
+                            controlEndpoint.getOutputStream().write(0);
                             sendDummyByte = false;
                         }
                     }
                 }
             } else {
                 if (video) {
-                    videoSocket = connect(socketName);
+                    videoEndpoint = new LocalSocketEndpoint(connect(socketName));
                 }
                 if (audio) {
-                    audioSocket = connect(socketName);
+                    audioEndpoint = new LocalSocketEndpoint(connect(socketName));
                 }
                 if (control) {
-                    controlSocket = connect(socketName);
+                    controlEndpoint = new LocalSocketEndpoint(connect(socketName));
                 }
             }
-        } catch (IOException | RuntimeException e) {
-            if (videoSocket != null) {
-                videoSocket.close();
-            }
-            if (audioSocket != null) {
-                audioSocket.close();
-            }
-            if (controlSocket != null) {
-                controlSocket.close();
-            }
-            throw e;
-        }
 
-        return new DesktopConnection(videoSocket, audioSocket, controlSocket);
+            DesktopConnection connection = new DesktopConnection(videoEndpoint, audioEndpoint, controlEndpoint);
+            videoEndpoint = null;
+            audioEndpoint = null;
+            controlEndpoint = null;
+            return connection;
+        } finally {
+            closeSilently(videoEndpoint);
+            closeSilently(audioEndpoint);
+            closeSilently(controlEndpoint);
+        }
     }
 
-    private LocalSocket getFirstSocket() {
-        if (videoSocket != null) {
-            return videoSocket;
+    private static DesktopConnection openTcp(String listenAddress, int listenPort, boolean video, boolean audio, boolean control,
+            boolean sendDummyByte) throws IOException {
+        ServerSocket serverSocket = new ServerSocket();
+        Endpoint videoEndpoint = null;
+        Endpoint audioEndpoint = null;
+        Endpoint controlEndpoint = null;
+        try {
+            serverSocket.setReuseAddress(true);
+            int port = listenPort >= 0 ? listenPort : 0;
+            InetSocketAddress socketAddress;
+            if (listenAddress != null && !listenAddress.isEmpty()) {
+                InetAddress inetAddress = InetAddress.getByName(listenAddress);
+                socketAddress = new InetSocketAddress(inetAddress, port);
+            } else {
+                socketAddress = new InetSocketAddress(port);
+            }
+            serverSocket.bind(socketAddress);
+
+            if (video) {
+                Socket socket = serverSocket.accept();
+                socket.setTcpNoDelay(true);
+                videoEndpoint = new TcpSocketEndpoint(socket);
+                if (sendDummyByte) {
+                    videoEndpoint.getOutputStream().write(0);
+                    sendDummyByte = false;
+                }
+            }
+            if (audio) {
+                Socket socket = serverSocket.accept();
+                socket.setTcpNoDelay(true);
+                audioEndpoint = new TcpSocketEndpoint(socket);
+                if (sendDummyByte) {
+                    audioEndpoint.getOutputStream().write(0);
+                    sendDummyByte = false;
+                }
+            }
+            if (control) {
+                Socket socket = serverSocket.accept();
+                socket.setTcpNoDelay(true);
+                controlEndpoint = new TcpSocketEndpoint(socket);
+                if (sendDummyByte) {
+                    controlEndpoint.getOutputStream().write(0);
+                    sendDummyByte = false;
+                }
+            }
+
+            DesktopConnection connection = new DesktopConnection(videoEndpoint, audioEndpoint, controlEndpoint);
+            videoEndpoint = null;
+            audioEndpoint = null;
+            controlEndpoint = null;
+            return connection;
+        } finally {
+            closeSilently(videoEndpoint);
+            closeSilently(audioEndpoint);
+            closeSilently(controlEndpoint);
+            try {
+                serverSocket.close();
+            } catch (IOException e) {
+                // ignore
+            }
         }
-        if (audioSocket != null) {
-            return audioSocket;
+    }
+
+    private Endpoint getFirstEndpoint() {
+        if (videoEndpoint != null) {
+            return videoEndpoint;
         }
-        return controlSocket;
+        if (audioEndpoint != null) {
+            return audioEndpoint;
+        }
+        return controlEndpoint;
     }
 
     public void shutdown() throws IOException {
-        if (videoSocket != null) {
-            videoSocket.shutdownInput();
-            videoSocket.shutdownOutput();
+        if (videoEndpoint != null) {
+            videoEndpoint.shutdown();
         }
-        if (audioSocket != null) {
-            audioSocket.shutdownInput();
-            audioSocket.shutdownOutput();
+        if (audioEndpoint != null) {
+            audioEndpoint.shutdown();
         }
-        if (controlSocket != null) {
-            controlSocket.shutdownInput();
-            controlSocket.shutdownOutput();
+        if (controlEndpoint != null) {
+            controlEndpoint.shutdown();
         }
     }
 
     public void close() throws IOException {
-        if (videoSocket != null) {
-            videoSocket.close();
+        if (videoEndpoint != null) {
+            videoEndpoint.close();
         }
-        if (audioSocket != null) {
-            audioSocket.close();
+        if (audioEndpoint != null) {
+            audioEndpoint.close();
         }
-        if (controlSocket != null) {
-            controlSocket.close();
+        if (controlEndpoint != null) {
+            controlEndpoint.close();
         }
     }
 
@@ -160,7 +341,7 @@ public final class DesktopConnection implements Closeable {
         System.arraycopy(deviceNameBytes, 0, buffer, 0, len);
         // byte[] are always 0-initialized in java, no need to set '\0' explicitly
 
-        FileDescriptor fd = getFirstSocket().getFileDescriptor();
+        FileDescriptor fd = getFirstEndpoint().getFileDescriptor();
         IO.writeFully(fd, buffer, 0, buffer.length);
     }
 


### PR DESCRIPTION
## Summary
- add listen address/port options to the server configuration parsing
- support both local sockets and TCP sockets in `DesktopConnection`, keeping metadata and dummy-byte behavior
- select the appropriate connection mode from `Server.scrcpy()` based on the parsed options

## Testing
- ./gradlew server:compileReleaseJavaWithJavac *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dbfe203b2c8324a7f457be1cb23d66